### PR TITLE
updating the dataset and judgements

### DIFF
--- a/train/prepare.sh
+++ b/train/prepare.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 wget https://repo1.maven.org/maven2/com/o19s/RankyMcRankFace/0.1.1/RankyMcRankFace-0.1.1.jar
-wget http://es-learn-to-rank.labs.o19s.com/tmdb.json
+curl -L -o tmdb.json http://es-learn-to-rank.labs.o19s.com/tmdb_ai_pow_search.json
+curl -L -o movie_judgements.txt http://es-learn-to-rank.labs.o19s.com/ai_pow_search_judgments.txt
 wget http://files.grouplens.org/datasets/movielens/ml-20m.zip
 unzip ml-20m.zip


### PR DESCRIPTION
The current dataset is old from 2017. all the "poster_path" in that dataset are broken. with these new changes, we can get all the correct data, with the correct poster_path, along with the movie judgments for the new dataset.

I have changed the 'wget' to 'curl', since it was giving a connection issue sometimes.

I have tested it and it is working fine with these changes.